### PR TITLE
chore: prep vscode for sideloading

### DIFF
--- a/.changeset/nice-walls-jog.md
+++ b/.changeset/nice-walls-jog.md
@@ -1,0 +1,5 @@
+---
+"@rhds/tokens": minor
+---
+
+Prepare vscode plugin for sideloading

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: npx changeset publish
+          publish: npm run publish
           commit: "chore: version package"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.js
+++ b/build.js
@@ -212,7 +212,7 @@ export default resetStyles;`,
 /**
  * Exports VSCode style snippets for editor support
  */
-StyleDictionary.registerFormat({ name: 'snippets/vscode',
+StyleDictionary.registerFormat({ name: 'editor/vscode',
   formatter: ({ dictionary }) =>
     JSON.stringify(Object.fromEntries(
       dictionary.allTokens.map(token => {
@@ -229,6 +229,21 @@ StyleDictionary.registerFormat({ name: 'snippets/vscode',
             },
         ]
       })), null, 2),
+});
+
+/**
+ * Exports TextMate style snippets for editor support
+ * @example ```snippets
+ * snippet --rh-color-blackb
+ *   var(--rh-color-black, #000)
+ * ```
+ */
+StyleDictionary.registerFormat({ name: 'editor/textmate',
+  formatter: ({ dictionary }) => dictionary.allTokens.reduce((snippets, token) => `${snippets}
+snippet --${token.name}
+  var(--${token.name}, ${token.value})${!token.value?.startsWith?.('#') ? '' : `
+snippet ${token.value.replace(/^#/, '')}
+  var(--${token.name}, ${token.value})`}`, ''),
 });
 
 /**
@@ -415,10 +430,13 @@ StyleDictionary.extend({
       buildPath: 'editor/',
       prefix: 'rh',
       files: [{
-        destination: 'vscode.json',
-        format: 'snippets/vscode',
+        destination: 'vscode/snippets.json',
+        format: 'editor/vscode',
       }, {
-        destination: 'hexokinase.json',
+        destination: 'textmate/css.snippets',
+        format: 'editor/textmate',
+      }, {
+        destination: 'neovim/hexokinase.json',
         format: 'editor/hexokinase',
       }]
     }

--- a/package.json
+++ b/package.json
@@ -4,43 +4,44 @@
   "description": "Red Hat Design System Tokens",
   "scripts": {
     "build": "wireit",
+    "publish": "wireit",
+    "version": "wireit",
     "start": "wireit"
-  },
-  "type": "module",
-  "main": "js/tokens.cjs",
-  "module": "js/tokens.js",
-  "exports": {
-    ".": {
-      "import": "build/js/tokens.js",
-      "require": "build/js/tokens.cjs"
-    }
-  },
-  "files": [
-    "css",
-    "editor",
-    "js",
-    "json",
-    "scss"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
   },
   "wireit": {
     "build": {
-      "command": "node build.js",
+      "command": "node build.js && node sync.js",
       "files": [
         "tokens/**/*",
         "docs/**/*",
         "build.js"
       ],
       "output": [
-        "build/**",
-        "css/**",
-        "editor/**",
-        "js/**",
-        "json/**",
-        "scss/**"
+        "build/**/*",
+        "css/**/*",
+        "editor/**/*",
+        "js/**/*",
+        "json/**/*",
+        "scss/**/*"
+      ]
+    },
+    "version": {
+      "command": "npx changeset version && node sync.js",
+      "dependencies": [
+        "build"
+      ],
+      "files": [
+        "package.json"
+      ],
+      "output": [
+        "CHANGELOG.md",
+        "editor/vscode/package.json"
+      ]
+    },
+    "publish": {
+      "command": "npx changeset publish",
+      "dependencies": [
+        "version"
       ]
     },
     "start": {
@@ -50,19 +51,26 @@
       ]
     }
   },
-  "categories": [
-    "Snippets"
+  "type": "module",
+  "main": "js/tokens.cjs",
+  "module": "js/tokens.js",
+  "exports": {
+    ".": {
+      "import": "./js/tokens.js",
+      "require": "./js/tokens.cjs"
+    }
+  },
+  "files": [
+    "css",
+    "editor",
+    "editor/vscode/package.json",
+    "js",
+    "json",
+    "scss"
   ],
-  "contributes": {
-    "snippets": [
-      {
-        "language": [
-          "css",
-          "scss"
-        ],
-        "path": "./editor/vscode.json"
-      }
-    ]
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
     "@changesets/cli": "^2.22.0",
@@ -73,5 +81,13 @@
     "style-dictionary": "^3.7.0",
     "wireit": "^0.4.3",
     "yaml": "^2.1.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/redhat-ux/red-hat-design-tokens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/redhat-ux/red-hat-design-tokens"
+  },
+  "homepage": "https://red-hat-design-tokens.netlify.app"
 }

--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,41 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const TEMPLATE = {
+  "name": "red-hat-design-tokens",
+  "publisher": "Red Hat UX",
+  "engines": {
+    "vscode": "^0"
+  },
+  "license": "MIT",
+  "description": "Red Hat Design System Tokens",
+  "displayName": "Red Hat Design Tokens",
+  "categories": [
+    "Snippets"
+  ],
+  "contributes": {
+    "snippets": [
+      {
+        "language": "css",
+        "path": "snippets.json"
+      },
+      {
+        "language": "scss",
+        "path": "snippets.json"
+      }
+    ]
+  },
+  "bugs": {
+    "url": "https://github.com/redhat-ux/red-hat-design-tokens/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/redhat-ux/red-hat-design-tokens"
+  },
+  "homepage": "https://red-hat-design-tokens.netlify.app"
+}
+
+
+const PATH = new URL('editor/vscode/package.json', import.meta.url);
+const { version } = JSON.parse(await readFile(new URL('package.json', import.meta.url), 'utf8'));
+
+await writeFile(PATH, JSON.stringify({...TEMPLATE, version }, null, 2), 'utf8')


### PR DESCRIPTION
generates the vscode extention package json
Users should copy the vscode dir into `.vscode/extensions`

Also adds a textmate output