### PR TITLE
fix(typography): font families and i18n fallbacks

### DIFF
--- a/.changeset/empty-cars-juggle.md
+++ b/.changeset/empty-cars-juggle.md
@@ -1,0 +1,5 @@
+---
+"@rhds/tokens": patch
+---
+
+Support a limited set of languages in font-family

--- a/build.js
+++ b/build.js
@@ -114,8 +114,8 @@ StyleDictionary.registerTransform({ name: 'dtcg/cubic-bezier/css',
 StyleDictionary.registerTransform({ name: 'dtcg/font-family/css',
   type: 'value',
   matcher: isFontFamily,
-  transformer: ({ value }) =>
-    `${value.join(', ')}`,
+  transformer: /**@param {{value: string[]}} value */({ value }) =>
+    `${value.map(x => x.match(/\s/) ? `"${x}"` : x).join(', ')}`,
 })
 
 /**

--- a/build.js
+++ b/build.js
@@ -11,10 +11,21 @@ import flattenTokens from 'style-dictionary/lib/utils/flattenProperties.js';
 import nunjucks from 'nunjucks';
 import slugify from '@sindresorhus/slugify';
 import markdownit from 'markdown-it';
+import hljs from 'highlight.js';
 
 const md = markdownit({
   html: true,
   linkify: true,
+  highlight(str, language) {
+    if (hljs.getLanguage(language)) {
+      try {
+        return hljs.highlight(str, { language }).value;
+      } catch(e) {
+        console.error(e)
+        return str;
+      }
+    }
+  }
 });
 
 const env = nunjucks.configure(fileURLToPath(new URL('./docs', import.meta.url)));

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,12 @@
     <meta name="viewport" content="width=device-width">
     <title>Red Hat Design System</title>
     <link rel="shortcut icon" href="https://www.redhat.com/misc/favicon.ico" type="image/x-icon" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://static.redhat.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://static.redhat.com/libs/redhat/redhat-font/4/webfonts/red-hat-font.min.css">
     <link rel="stylesheet" href="https://static.redhat.com/libs/redhat/redhat-theme/4/advanced-theme.css">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Hebrew:wght@300;500;700&family=Noto+Sans+JP:wght@300;500;700&family=Noto+Sans+KR:wght@300;500;700&family=Noto+Sans+Malayalam:wght@300;500;700&family=Noto+Sans+SC:wght@300;500;700&family=Noto+Sans+TC:wght@300;500;700&family=Noto+Sans+Tamil:wght@300;500;700&family=Noto+Sans+Thai:wght@300;500;700&display=swap" rel="stylesheet"> 
     <link rel="stylesheet" href="rhds.css">
     <link rel="stylesheet" href="styles.css">
     <style></style>

--- a/docs/macros.html
+++ b/docs/macros.html
@@ -194,6 +194,7 @@
     {% else %}
       {%- call table(collection, output = docs.example, name = name) -%}{%- endcall -%}
     {% endif %}
+    <a class="btt" href="#">Top</a>
   </section>
 {%- endmacro -%}
 
@@ -210,5 +211,6 @@
     {% else %}
       {%- call table(collection, output = docs.example, rowType = rowType, name = name) -%}{%- endcall -%}
     {% endif %}
+    <a class="btt" href="#">Top</a>
   </section>
 {%- endmacro -%}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -260,3 +260,18 @@ output.swatch.light {
   display: none;
 }
 
+.btt {
+  text-align: right;
+  display: block;
+}
+
+.language-html .hljs-tag { color: var(--rh-color-blue-500, #004080); }
+.language-html .hljs-name { color: var(--rh-color-brand-red-dark, #be0000); }
+.language-html .hljs-attr { color: var(--rh-color-orange-300, #ec7a08); }
+.language-html .hljs-string { color: var(--rh-color-green-500, #3e8635); }
+
+code[class^="language-"] { 
+  max-width: 100%;
+  display: block;
+  overflow-x: scroll;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@rhds/tokens",
-  "version": "0.0.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rhds/tokens",
-      "version": "0.0.0",
+      "version": "1.0.0-beta.1",
       "devDependencies": {
         "@changesets/cli": "^2.22.0",
         "@sindresorhus/slugify": "^2.1.0",
         "@web/dev-server": "^0.1.31",
+        "highlight.js": "^11.6.0",
         "markdown-it": "^13.0.1",
         "nunjucks": "^3.2.3",
         "style-dictionary": "^3.7.0",
@@ -2566,6 +2567,15 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -6946,6 +6956,12 @@
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.9",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@changesets/cli": "^2.22.0",
     "@sindresorhus/slugify": "^2.1.0",
     "@web/dev-server": "^0.1.31",
+    "highlight.js": "^11.6.0",
     "markdown-it": "^13.0.1",
     "nunjucks": "^3.2.3",
     "style-dictionary": "^3.7.0",

--- a/tokens/font/family.yml
+++ b/tokens/font/family.yml
@@ -16,8 +16,18 @@ font:
         com.redhat.ux:
           example: Display
       value:
-        - '"RedHatDisplay"'
-        - '"Overpass"'
+        - RedHatDisplay
+        - Red Hat Display
+        - Noto Sans Arabic
+        - Noto Sans Devanagari
+        - Noto Sans Hebrew
+        - Noto Sans Japanese
+        - Noto Sans Korean
+        - Noto Sans Malayalam
+        - Noto Sans Simplified Chinese
+        - Noto Sans Tamil
+        - Noto Sans Thai
+        - Noto Sans Traditional Chinese
         - Overpass
         - Helvetica
         - Arial
@@ -29,8 +39,14 @@ font:
         com.redhat.ux:
           example: Body text
       value:
-        - '"RedHatText"'
-        - '"Overpass"'
+        - RedHatText
+        - Red Hat Text
+        - Noto Sans Hebrew
+        - Noto Sans Japanese
+        - Noto Sans Korean
+        - Noto Sans Traditional Chinese
+        - Noto Sans Simplified Chinese
+        - Noto Sans Arabic
         - Overpass
         - Helvetica
         - Arial
@@ -42,7 +58,8 @@ font:
         com.redhat.ux:
           example: Code
       value:
-        - '"RedHatMono"'
-        - '"Courier New"'
+        - RedHatMono
+        - Red Hat Mono
+        - Courier New
         - Courier
         - monospace

--- a/tokens/font/family.yml
+++ b/tokens/font/family.yml
@@ -4,10 +4,24 @@ font:
     $extensions:
       com.redhat.ux:
         heading: Font family
-        description: >-
-          **Font Family** Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sed ad repellendus eius autem
-          architecto, sapiente error ratione ab. Labore, enim blanditiis quam veniam sint totam
-          asperiores aliquid distinctio consectetur obcaecati?
+        description: |-
+          [Red Hat Fonts](https://github.com/RedHatOfficial/RedHatFont), designed by Jeremy Mickel
+          and released under Open Font License, form the typographic basis for the Red Hat Design
+          System. Pages using non-latin characters should fall back to
+          [Noto Sans](https://github.com/notofonts/noto-fonts). By loading language-specific Noto 
+          Sans fonts, <abbr title="Red Hat Design System">RHDS</abbr> can accomodate mixed-language
+          content including <span lang="ar">العربية</span>, <span lang="he">עברית</span>,
+          <span lang="jp">日本語</span>, <span lang="kr">조선말</span>, <span lang="ml">മലയാളം</span>,
+          <span lang="zh">汉语</span>, <span lang="zh">漢語</span>, or <span lang="th">ภาษาไทย</span>.
+
+          Users may load those fonts from Google Fonts, for example with this HTML snippet pasted
+          into the `<head>`:
+
+          ```html
+          <link rel="preconnect" href="https://fonts.googleapis.com">
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+          <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Hebrew:wght@300;500;700&family=Noto+Sans+JP:wght@300;500;700&family=Noto+Sans+KR:wght@300;500;700&family=Noto+Sans+Malayalam:wght@300;500;700&family=Noto+Sans+SC:wght@300;500;700&family=Noto+Sans+TC:wght@300;500;700&family=Noto+Sans+Tamil:wght@300;500;700&family=Noto+Sans+Thai:wght@300;500;700&display=swap" rel="stylesheet"> 
+          ```
 
     heading:
       $type: fontFamily
@@ -19,15 +33,13 @@ font:
         - RedHatDisplay
         - Red Hat Display
         - Noto Sans Arabic
-        - Noto Sans Devanagari
         - Noto Sans Hebrew
-        - Noto Sans Japanese
-        - Noto Sans Korean
+        - Noto Sans JP
+        - Noto Sans KR
         - Noto Sans Malayalam
-        - Noto Sans Simplified Chinese
-        - Noto Sans Tamil
+        - Noto Sans SC
+        - Noto Sans TC
         - Noto Sans Thai
-        - Noto Sans Traditional Chinese
         - Overpass
         - Helvetica
         - Arial
@@ -41,12 +53,14 @@ font:
       value:
         - RedHatText
         - Red Hat Text
-        - Noto Sans Hebrew
-        - Noto Sans Japanese
-        - Noto Sans Korean
-        - Noto Sans Traditional Chinese
-        - Noto Sans Simplified Chinese
         - Noto Sans Arabic
+        - Noto Sans Hebrew
+        - Noto Sans JP
+        - Noto Sans KR
+        - Noto Sans Malayalam
+        - Noto Sans SC
+        - Noto Sans TC
+        - Noto Sans Thai
         - Overpass
         - Helvetica
         - Arial


### PR DESCRIPTION
## What I did
Add "Red Hat Text/Display/Mono" to font stack
Add some Noto Sans i18n fallbacks for select languages

## Notes to Reviewers
Some guidance on [which languages](https://fonts.google.com/noto/fonts) to list would be useful. Presumably "Linear A" and Shavian are not on the menu :wink: 

Resulting font-family values:
```css
--rh-font-family-heading: RedHatDisplay, "Red Hat Display", "Noto Sans Arabic", "Noto Sans Devanagari", "Noto Sans Hebrew", "Noto Sans Japanese", "Noto Sans Korean", "Noto Sans Malayalam", "Noto Sans Simplified Chinese", "Noto Sans Tamil", "Noto Sans Thai", "Noto Sans Traditional Chinese", Overpass, Helvetica, Arial, sans-serif; /* Heading font family */
--rh-font-family-body-text: RedHatText, "Red Hat Text", "Noto Sans Hebrew", "Noto Sans Japanese", "Noto Sans Korean", "Noto Sans Traditional Chinese", "Noto Sans Simplified Chinese", "Noto Sans Arabic", Overpass, Helvetica, Arial, sans-serif; /* Body text font family */
--rh-font-family-code: RedHatMono, "Red Hat Mono", "Courier New", Courier, monospace; /* Code font family */
```
Closes #17 