### PR TITLE
fix(11ty): copy-button issues

### DIFF
--- a/.changeset/olive-trainers-listen.md
+++ b/.changeset/olive-trainers-listen.md
@@ -1,0 +1,9 @@
+---
+"@rhds/tokens": minor
+---
+
+11ty plugin: Fixed copy button
+
+- Fixed copy button when token values contain double-quotes
+- Used token colours for copy button
+- Made the docs extension key configurable (defaults to `com.redhat.ux`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '18'
           cache: npm
 
       # Set up GitHub Actions caching for Wireit.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
+      - auto_merge_enabled
+  push:
+    branches:
+      - main
 
 jobs:
   release:

--- a/plugins/11ty.cjs
+++ b/plugins/11ty.cjs
@@ -82,7 +82,11 @@ function table({ tokens, name = '', docs } = {}) {
         const isColor = !!token.path.includes('color');
         const isCrayon = isColor && token.name.match(/0$/);
         const isHSLorRGB = !!token.name.match(/(hsl|rgb)$/);
-        const variable = `var(--${token.name}, ${token.$value})`;
+        let variable = `var(--${token.name}, ${token.$value})`;
+
+        if (isFamily) {
+          variable = variable.replace(/"/g, "'");
+        }
 
         return isHSLorRGB ? '' : /* html */`
         <tr id="${token.name}"

--- a/plugins/11ty.cjs
+++ b/plugins/11ty.cjs
@@ -85,7 +85,7 @@ function table({ tokens, name = '', docs } = {}) {
         let variable = `var(--${token.name}, ${token.$value})`;
 
         if (isFamily) {
-          variable = variable.replace(/"/g, "'");
+          variable = variable.replace(/"/g, '\'');
         }
 
         return isHSLorRGB ? '' : /* html */`

--- a/plugins/11ty/styles.css
+++ b/plugins/11ty/styles.css
@@ -84,6 +84,7 @@ tr {
 tr.on-dark {
   background-color: var(--rh-color-surface-darkest, #151515);
   color: var(--rh-color-text-primary-on-dark, #ffffff);
+  fill: var(--rh-color-text-primary-on-dark, #ffffff);
 }
 
 th, td {

--- a/plugins/11ty/styles.css
+++ b/plugins/11ty/styles.css
@@ -84,7 +84,6 @@ tr {
 tr.on-dark {
   background-color: var(--rh-color-surface-darkest, #151515);
   color: var(--rh-color-text-primary-on-dark, #ffffff);
-  fill: var(--rh-color-text-primary-on-dark, #ffffff);
 }
 
 th, td {
@@ -105,11 +104,6 @@ td.token > div {
 
 .hex {
   text-transform: uppercase;
-}
-
-.copy-cell {
-  text-align: end;
-  vertical-align: middle;
 }
 
 section {
@@ -152,11 +146,14 @@ code {
   padding: var(--rh-space-xs);
   background: none;
   cursor: pointer;
-  opacity: 0.2;
+}
+
+.copy-button svg {
+  width: 24px;
+  fill: currentcolor;
 }
 
 .copy-button:is(.value, .name) {
-  opacity: 1;
   background-color: var(--rh-color-surface-lighter);
   overflow-x: hidden;
   max-width: 350px;
@@ -192,12 +189,25 @@ code {
   background: var(--rh-color-interactive-blue-darker);
 }
 
-.copy-button svg {
-  width: 24px;
+.copy-cell {
+  text-align: end;
+  vertical-align: middle;
 }
 
-tr:is(:hover, :focus-within) .copy-button {
-  opacity: 1;
+.copy-cell .copy-button {
+  color: var(--rh-color-icon-subtle);
+}
+
+.on-dark .copy-cell .copy-button {
+  color: var(--rh-color-icon-subtle-hover);
+}
+
+tr:is(:hover, :focus-within) .copy-cell .copy-button {
+  color: var(--rh-color-icon-secondary-on-light);
+}
+
+tr:is(:hover, :focus-within).on-dark .copy-cell .copy-button {
+  color: var(--rh-color-icon-secondary-on-dark);
 }
 
 .font samp {

--- a/tokens/color/text.yaml
+++ b/tokens/color/text.yaml
@@ -23,6 +23,7 @@ color:
           colors. Layouts with colored backgrounds or a photo changes the rules regarding the
           placement of text, so use white or black text for body copy applications.
 
+
           [wcag]: https://www.w3.org/WAI/WCAG2AA-Conformance.html
 
     primary:


### PR DESCRIPTION
Currently if the user clicks on the `copy` icon on a `font-family` style they will get only a partial token as the double quotes terminates the string early.

This PR adds a replace for those font family styles to replace any `"` with a single quote `'`.  

Also a small CSS update to the dark theme icons so they have the same fill color as the text.