### PR TITLE
fix: remap new gray surface tokens

### DIFF
--- a/.changeset/tough-cars-dance.md
+++ b/.changeset/tough-cars-dance.md
@@ -1,0 +1,5 @@
+---
+"@rhds/tokens": patch
+---
+
+Remapped new gray surface tokens and added a description for canvas tokens

--- a/tokens/color/canvas.yaml
+++ b/tokens/color/canvas.yaml
@@ -4,7 +4,7 @@ color:
       com.redhat.ux:
         order: 200
         description: >-
-        The canvas tokens should be used for page backgrounds only. To add a background to contained sections, use a surface token.
+          The canvas tokens should be used for page backgrounds only. To add a background to contained sections, use a surface token.
 
     white:
       $value: '{color.white}'

--- a/tokens/color/canvas.yaml
+++ b/tokens/color/canvas.yaml
@@ -3,6 +3,8 @@ color:
     $extensions:
       com.redhat.ux:
         order: 200
+        description: >-
+        The canvas tokens should be used for page backgrounds only. To add a background to contained sections, use a surface token.
 
     white:
       $value: '{color.white}'

--- a/tokens/color/crayon/gray.yaml
+++ b/tokens/color/crayon/gray.yaml
@@ -1,7 +1,7 @@
 color:
   white:
     $value: '#ffffff'
-    $description: Primary canvas (light theme) or primary text (dark theme)
+    $description: Lightest surface (light theme) or primary text (dark theme)
     attributes:
       type: gray
 
@@ -15,17 +15,17 @@ color:
 
     '05':
       $value: '#F2F2F2'
-      $description: Primary surface (light theme)
+      $description: Tertiary surface (light theme)
       attributes:
         type: gray
     '10':
       $value: '#E0E0E0'
-      $description: Tertiary surface (light theme)
+      $description: Secondary surface (light theme)
       attributes:
         type: gray
     '20':
       $value: '#C7C7C7'
-      $description: Secondary surface (light theme) or subtle borders (light theme)
+      $description: Subtle borders (light theme)
       attributes:
         type: gray
     '30':
@@ -50,17 +50,17 @@ color:
         type: gray
     '70':
       $value: '#292929'
-      $description: Secondary surface (dark theme)
+      $description: 
       attributes:
         type: gray
     '80':
       $value: '#1F1F1F'
-      $description: Primary surface (dark theme)
+      $description: Secondary surface (dark theme)
       attributes:
         type: gray
     '90':
       $value: '#151515'
-      $description: Primary canvas (dark theme) or primary text (light theme)
+      $description: Primary surface (dark theme) or primary text (light theme)
       attributes:
         type: gray
 

--- a/tokens/color/surface.yaml
+++ b/tokens/color/surface.yaml
@@ -4,27 +4,24 @@ color:
       com.redhat.ux:
         order: 250
 
-    white:
-      $value: '{color.white}'
-      $description: White surface (light theme)
     lightest:
-      $value: '{color.gray.05}'
+      $value: '{color.white}'
       $description: Primary surface (light theme)
     lighter:
-      $value: '{color.gray.10}'
+      $value: '{color.gray.05}'
       $description: Tertiary surface (light theme)
     light:
-      $value: '{color.gray.20}'
+      $value: '{color.gray.10}'
       $description: Secondary surface (light theme)
     dark:
       $value: '{color.gray.60}'
       $description: Tertiary surface (dark theme)
-    darker:
+    dark-alt:
       $value: '{color.gray.70}'
+      $description: Alternative tertiary surface (not available for use with context provider)
+    darker:
+      $value: '{color.gray.80}'
       $description: Secondary surface (dark theme)
     darkest:
-      $value: '{color.gray.80}'
-      $description: Primary surface (dark theme)
-    black: 
       $value: '{color.gray.90}'
-      $description: Black surface (dark theme)
+      $description: Primary surface (dark theme)

--- a/tokens/color/surface.yaml
+++ b/tokens/color/surface.yaml
@@ -13,6 +13,9 @@ color:
     light:
       $value: '{color.gray.10}'
       $description: Secondary surface (light theme)
+    light-alt:
+      $value: '{color.gray.20}'
+      $description: Alternative secondary surface (not available for use with context provider)
     dark:
       $value: '{color.gray.60}'
       $description: Tertiary surface (dark theme)


### PR DESCRIPTION
Remapped new gray surface tokens to keep `--rh-color-white` as the lightest surface token and `--rh-color-gray-90` as the darkest surface. Added `--rh-color-surface-dark-alt`, which won't be used by the context provider.