### PR TITLE
fix: plugin filename should match release tag

### DIFF
--- a/lib/release.js
+++ b/lib/release.js
@@ -38,12 +38,19 @@ export async function release({ core, github, tag, workspace }) {
 
     core.debug({ files });
 
-    const filename = files.find(file => file.endsWith('vsix'));
+    let filename = files.find(file => file.endsWith('vsix'));
 
     core.debug({ filename });
 
     if (!filename) {
       throw new Error('Could not find release');
+    }
+
+    // Filename should match release tag
+    const version = filename.slice(22, -5);
+    const releaseVersion = tag.slice(1);
+    if (version !== releaseVersion) {
+      filename = `red-hat-design-tokens-${releaseVersion}.vsix`;
     }
 
     const response = await backoff(() =>


### PR DESCRIPTION
Closes #101 

I mocked some of the inputs to the release function and tested locally with my JS debugger. Let me know if there's a better way to validate.