### PR TITLE
chore: missing script for types in release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "wireit",
     "lint": "eslint lib plugins test docs",
     "format": "eslint --fix lib plugins test docs",
-    "test": "wireit"
+    "test": "wireit",
+    "types": "wireit"
   },
   "type": "module",
   "main": "js/tokens.cjs",


### PR DESCRIPTION
## What I did
 - Added package.json script alias  for wireit `types` command 