### PR TITLE
feat: add status color tokens

### DIFF
--- a/.changeset/rich-bags-deliver.md
+++ b/.changeset/rich-bags-deliver.md
@@ -1,0 +1,22 @@
+---
+"@rhds/tokens": minor
+---
+
+Added status tokens
+
+```css
+button {
+  .light &.danger {
+    background: var(--rh-color-danger-on-light);
+  }
+  .light &.success {
+    background: var(--rh-color-success-on-light);
+  }
+  .dark &.danger {
+    background: var(--rh-color-danger-on-dark);
+  }
+  .dark &.success {
+    background: var(--rh-color-success-on-dark);
+  }
+}
+```

--- a/.changeset/rich-bags-deliver.md
+++ b/.changeset/rich-bags-deliver.md
@@ -7,16 +7,16 @@ Added status tokens
 ```css
 button {
   .light &.danger {
-    background: var(--rh-color-danger-on-light);
+    background: var(--rh-color-status-danger-on-light);
   }
   .light &.success {
-    background: var(--rh-color-success-on-light);
+    background: var(--rh-color-status-success-on-light);
   }
   .dark &.danger {
-    background: var(--rh-color-danger-on-dark);
+    background: var(--rh-color-status-danger-on-dark);
   }
   .dark &.success {
-    background: var(--rh-color-success-on-dark);
+    background: var(--rh-color-status-success-on-dark);
   }
 }
 ```

--- a/docs/assets/tokens.css
+++ b/docs/assets/tokens.css
@@ -185,7 +185,7 @@ code {
 .token:is(.value, .name) .copy-button {
   background-color: var(--rh-color-surface-lighter);
   overflow-x: hidden;
-  max-width: 350px;
+  max-width: 400px;
   white-space: pre;
   text-overflow: ellipsis;
 }

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -48,3 +48,89 @@ color:
         attributes:
           category: border
           type: color
+
+    danger:
+
+      on-light:
+        $value: '{color.red-orange.50}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+      on-dark:
+        $value: '{color.red-orange.40}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+
+    warning:
+
+      on-light:
+        $value: '{color.orange.50}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+      on-dark:
+        $value: '{color.orange.40}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+
+    caution:
+      on-light:
+        $value: '{color.yellow.60}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+      on-dark:
+        $value: '{color.yellow.30}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+
+    neutral:
+      on-light:
+        $value: '{color.gray.60}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+      on-dark:
+        $value: '{color.gray.40}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+
+    note:
+      on-light:
+        $value: '{color.purple.50}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+      on-dark:
+        $value: '{color.purple.30}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+
+    success:
+      on-light:
+        $value: '{color.green.60}'
+        $description: 
+        attributes:
+          category: border
+          type: color
+      on-dark:
+        $value: '{color.green.40}'
+        $description: 
+        attributes:
+          category: border
+          type: color

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -50,7 +50,6 @@ color:
           type: color
 
     danger:
-
       on-light:
         $value: '{color.red-orange.50}'
         $description: Danger border color (light theme)

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -53,28 +53,27 @@ color:
 
       on-light:
         $value: '{color.red-orange.50}'
-        $description: 
+        $description: Danger border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.red-orange.40}'
-        $description: 
+        $description: Danger border color (dark theme)
         attributes:
           category: border
           type: color
 
     warning:
-
       on-light:
         $value: '{color.orange.50}'
-        $description: 
+        $description: Warning border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.orange.40}'
-        $description: 
+        $description: Warning border color (dark theme)
         attributes:
           category: border
           type: color
@@ -82,13 +81,13 @@ color:
     caution:
       on-light:
         $value: '{color.yellow.60}'
-        $description: 
+        $description: Caution border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.yellow.30}'
-        $description: 
+        $description: Caution border color (dark theme)
         attributes:
           category: border
           type: color
@@ -96,13 +95,13 @@ color:
     neutral:
       on-light:
         $value: '{color.gray.60}'
-        $description: 
+        $description: Neutral status border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.gray.40}'
-        $description: 
+        $description: Neutral status border color (dark theme)
         attributes:
           category: border
           type: color
@@ -110,13 +109,13 @@ color:
     note:
       on-light:
         $value: '{color.purple.50}'
-        $description: 
+        $description: Note border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.purple.30}'
-        $description: 
+        $description: Note border color (dark theme)
         attributes:
           category: border
           type: color
@@ -124,13 +123,13 @@ color:
     success:
       on-light:
         $value: '{color.green.60}'
-        $description: 
+        $description: Success border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.green.40}'
-        $description: 
+        $description: Success border color (dark theme)
         attributes:
           category: border
           type: color

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -91,30 +91,30 @@ color:
           category: border
           type: color
 
-    neutral:
+    default:
       on-light:
         $value: '{color.gray.60}'
-        $description: Neutral status border color (light theme)
+        $description: Default status border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.gray.40}'
-        $description: Neutral status border color (dark theme)
+        $description: Default status border color (dark theme)
         attributes:
           category: border
           type: color
 
-    note:
+    info:
       on-light:
         $value: '{color.purple.50}'
-        $description: Note border color (light theme)
+        $description: Info border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
         $value: '{color.purple.30}'
-        $description: Note border color (dark theme)
+        $description: Info border color (dark theme)
         attributes:
           category: border
           type: color

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -49,86 +49,69 @@ color:
           category: border
           type: color
 
-    danger:
-      on-light:
-        $value: '{color.red-orange.50}'
-        $description: Danger border color (light theme)
-        attributes:
-          category: border
-          type: color
-      on-dark:
-        $value: '{color.red-orange.40}'
-        $description: Danger border color (dark theme)
-        attributes:
-          category: border
-          type: color
-
-    warning:
-      on-light:
-        $value: '{color.orange.50}'
-        $description: Warning border color (light theme)
-        attributes:
-          category: border
-          type: color
-      on-dark:
-        $value: '{color.orange.40}'
-        $description: Warning border color (dark theme)
-        attributes:
-          category: border
-          type: color
-
-    caution:
-      on-light:
-        $value: '{color.yellow.60}'
-        $description: Caution border color (light theme)
-        attributes:
-          category: border
-          type: color
-      on-dark:
-        $value: '{color.yellow.30}'
-        $description: Caution border color (dark theme)
-        attributes:
-          category: border
-          type: color
-
-    default:
-      on-light:
-        $value: '{color.gray.60}'
-        $description: Default status border color (light theme)
-        attributes:
-          category: border
-          type: color
-      on-dark:
-        $value: '{color.gray.40}'
-        $description: Default status border color (dark theme)
-        attributes:
-          category: border
-          type: color
-
-    info:
-      on-light:
-        $value: '{color.purple.50}'
-        $description: Info border color (light theme)
-        attributes:
-          category: border
-          type: color
-      on-dark:
-        $value: '{color.purple.30}'
-        $description: Info border color (dark theme)
-        attributes:
-          category: border
-          type: color
-
-    success:
-      on-light:
-        $value: '{color.green.60}'
-        $description: Success border color (light theme)
-        attributes:
-          category: border
-          type: color
-      on-dark:
-        $value: '{color.green.40}'
-        $description: Success border color (dark theme)
-        attributes:
-          category: border
-          type: color
+    status:
+      danger:
+        on-light:
+          $value: '{color.red-orange.50}'
+          $description: Danger status border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.red-orange.40}'
+          $description: Danger status border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      warning:
+        on-light:
+          $value: '{color.orange.50}'
+          $description: Warning status border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.orange.40}'
+          $description: Warning status border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      default:
+        on-light:
+          $value: '{color.gray.60}'
+          $description: Default status border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.gray.40}'
+          $description: Default status border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      info:
+        on-light:
+          $value: '{color.purple.50}'
+          $description: Info status border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.purple.30}'
+          $description: Info status border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      success:
+        on-light:
+          $value: '{color.green.60}'
+          $description: Success status border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.green.40}'
+          $description: Success status border color (dark theme)
+          attributes:
+            category: border
+            type: color

--- a/tokens/color/crayon/blue.yaml
+++ b/tokens/color/crayon/blue.yaml
@@ -2,7 +2,7 @@ color:
   blue:
     $extensions:
       com.redhat.ux:
-        order: 301
+        order: 306
     10:
       $value: '#E0F0FF'
       $description: Alert - Info background

--- a/tokens/color/crayon/orange.yml
+++ b/tokens/color/crayon/orange.yml
@@ -2,7 +2,7 @@ color:
   orange:
     $extensions:
       com.redhat.ux:
-        order: 305
+        order: 302
     10:
       $value: '#FFE8CC'
       $description: Label - Filled (Orange) background color

--- a/tokens/color/crayon/purple.yaml
+++ b/tokens/color/crayon/purple.yaml
@@ -2,7 +2,7 @@ color:
   purple:
     $extensions:
       com.redhat.ux:
-        order: 306
+        order: 307
     10:
       $value: '#ECE6FF'
       $description: Label - Filled (Purple) background color

--- a/tokens/color/crayon/red-orange.yaml
+++ b/tokens/color/crayon/red-orange.yaml
@@ -2,7 +2,7 @@ color:
   red-orange:
     $extensions:
       com.redhat.ux:
-        order: 303
+        order: 301
         description: >-
           The red orange color is reserved for danger or error states. Do not use it anywhere else.
 
@@ -15,7 +15,7 @@ color:
     40:
       $value: '#F4784A'
     50:
-      $value: '#F4784A'
+      $value: '#F0561D'
     60:
       $value: '#B1380B'
     70:

--- a/tokens/color/crayon/teal.yaml
+++ b/tokens/color/crayon/teal.yaml
@@ -4,7 +4,7 @@ color:
   teal:
     $extensions:
       com.redhat.ux:
-        order: 302
+        order: 305
     10:
       $value: '#DAF2F2'
       $description: Alert - Default background

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -7,89 +7,89 @@ color:
     danger:
       on-light:
         $value: '{color.red-orange.50}'
-        $description: 
+        $description: Danger accent color (light theme)
       on-dark:
         $value: '{color.red-orange.40}'
-        $description: 
+        $description: Danger accent color (dark theme)
       surface:
         on-light:
           $value: '{color.red-orange.10}'
-          $description: 
+          $description: Danger surface color (light theme)
         on-dark:
           $value: '{color.red-orange.70}'
-          $description: 
+          $description: Danger surface color (dark theme)
 
     warning:
       on-light:
         $value: '{color.orange.50}'
-        $description: 
+        $description: Warning accent color (light theme)
       on-dark:
         $value: '{color.orange.40}'
-        $description: 
+        $description: Warning accent color (dark theme)
       surface:
         on-light:
           $value: '{color.orange.10}'
-          $description: 
+          $description: Warning surface color (light theme)
         on-dark:
           $value: '{color.orange.70}'
-          $description: 
+          $description: Warning surface color (dark theme)
 
     caution:
       on-light:
         $value: '{color.yellow.60}'
-        $description: 
+        $description: Caution accent color (light theme)
       on-dark:
         $value: '{color.yellow.30}'
-        $description: 
+        $description: Caution accent color (dark theme)
       surface:
         on-light:
           $value: '{color.yellow.10}'
-          $description: 
+          $description: Caution surface color (light theme)
         on-dark:
           $value: '{color.yellow.70}'
-          $description: 
+          $description: Caution surface color (dark theme)
 
     neutral:
       on-light:
         $value: '{color.gray.60}'
-        $description: 
+        $description: Neutral accent color (light theme)
       on-dark:
         $value: '{color.gray.40}'
-        $description: 
+        $description: Neutral accent color (dark theme)
       surface:
         on-light:
           $value: '{color.gray.10}'
-          $description: 
+          $description: Neutral surface color (light theme)
         on-dark:
           $value: '{color.gray.80}'
-          $description: 
+          $description: Neutral surface color (dark theme)
 
     note:
       on-light:
         $value: '{color.purple.50}'
-        $description: 
+        $description: Note accent color (light theme)
       on-dark:
         $value: '{color.purple.30}'
-        $description: 
+        $description: Note accent color (dark theme)
       surface:
         on-light:
           $value: '{color.purple.10}'
-          $description: 
+          $description: Note surface color (light theme)
         on-dark:
           $value: '{color.purple.60}'
-          $description: 
+          $description: Note surface color (dark theme)
 
     success:
       on-light:
         $value: '{color.green.60}'
-        $description: 
+        $description: Success accent color (light theme)
       on-dark:
         $value: '{color.green.40}'
-        $description: 
+        $description: Success accent color (dark theme)
       surface:
         on-light:
           $value: '{color.green.10}'
-          $description: 
+          $description: Success surface color (light theme)
         on-dark:
           $value: '{color.green.70}'
-          $description: 
+          $description: Success surface color (dark theme)

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -11,13 +11,6 @@ color:
       on-dark:
         $value: '{color.red-orange.40}'
         $description: Danger accent color (dark theme)
-      surface:
-        on-light:
-          $value: '{color.red-orange.10}'
-          $description: Danger surface color (light theme)
-        on-dark:
-          $value: '{color.red-orange.70}'
-          $description: Danger surface color (dark theme)
 
     warning:
       on-light:
@@ -26,13 +19,6 @@ color:
       on-dark:
         $value: '{color.orange.40}'
         $description: Warning accent color (dark theme)
-      surface:
-        on-light:
-          $value: '{color.orange.10}'
-          $description: Warning surface color (light theme)
-        on-dark:
-          $value: '{color.orange.70}'
-          $description: Warning surface color (dark theme)
 
     caution:
       on-light:
@@ -41,13 +27,6 @@ color:
       on-dark:
         $value: '{color.yellow.30}'
         $description: Caution accent color (dark theme)
-      surface:
-        on-light:
-          $value: '{color.yellow.10}'
-          $description: Caution surface color (light theme)
-        on-dark:
-          $value: '{color.yellow.70}'
-          $description: Caution surface color (dark theme)
 
     neutral:
       on-light:
@@ -56,13 +35,6 @@ color:
       on-dark:
         $value: '{color.gray.40}'
         $description: Neutral accent color (dark theme)
-      surface:
-        on-light:
-          $value: '{color.gray.10}'
-          $description: Neutral surface color (light theme)
-        on-dark:
-          $value: '{color.gray.80}'
-          $description: Neutral surface color (dark theme)
 
     note:
       on-light:
@@ -71,13 +43,6 @@ color:
       on-dark:
         $value: '{color.purple.30}'
         $description: Note accent color (dark theme)
-      surface:
-        on-light:
-          $value: '{color.purple.10}'
-          $description: Note surface color (light theme)
-        on-dark:
-          $value: '{color.purple.60}'
-          $description: Note surface color (dark theme)
 
     success:
       on-light:
@@ -86,10 +51,3 @@ color:
       on-dark:
         $value: '{color.green.40}'
         $description: Success accent color (dark theme)
-      surface:
-        on-light:
-          $value: '{color.green.10}'
-          $description: Success surface color (light theme)
-        on-dark:
-          $value: '{color.green.70}'
-          $description: Success surface color (dark theme)

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -28,21 +28,21 @@ color:
         $value: '{color.yellow.30}'
         $description: Caution accent color (dark theme)
 
-    neutral:
+    default:
       on-light:
         $value: '{color.gray.60}'
-        $description: Neutral accent color (light theme)
+        $description: Default accent color (light theme)
       on-dark:
         $value: '{color.gray.40}'
-        $description: Neutral accent color (dark theme)
+        $description: Default accent color (dark theme)
 
-    note:
+    info:
       on-light:
         $value: '{color.purple.50}'
-        $description: Note accent color (light theme)
+        $description: Info accent color (light theme)
       on-dark:
         $value: '{color.purple.30}'
-        $description: Note accent color (dark theme)
+        $description: Info accent color (dark theme)
 
     success:
       on-light:

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -1,0 +1,95 @@
+color:
+  status:
+    $extensions:
+      com.redhat.ux:
+        order: 500
+
+    danger:
+      on-light:
+        $value: '{color.red-orange.50}'
+        $description: 
+      on-dark:
+        $value: '{color.red-orange.40}'
+        $description: 
+      surface:
+        on-light:
+          $value: '{color.red-orange.10}'
+          $description: 
+        on-dark:
+          $value: '{color.red-orange.70}'
+          $description: 
+
+    warning:
+      on-light:
+        $value: '{color.orange.50}'
+        $description: 
+      on-dark:
+        $value: '{color.orange.40}'
+        $description: 
+      surface:
+        on-light:
+          $value: '{color.orange.10}'
+          $description: 
+        on-dark:
+          $value: '{color.orange.70}'
+          $description: 
+
+    caution:
+      on-light:
+        $value: '{color.yellow.60}'
+        $description: 
+      on-dark:
+        $value: '{color.yellow.30}'
+        $description: 
+      surface:
+        on-light:
+          $value: '{color.yellow.10}'
+          $description: 
+        on-dark:
+          $value: '{color.yellow.70}'
+          $description: 
+
+    neutral:
+      on-light:
+        $value: '{color.gray.60}'
+        $description: 
+      on-dark:
+        $value: '{color.gray.40}'
+        $description: 
+      surface:
+        on-light:
+          $value: '{color.gray.10}'
+          $description: 
+        on-dark:
+          $value: '{color.gray.80}'
+          $description: 
+
+    note:
+      on-light:
+        $value: '{color.purple.50}'
+        $description: 
+      on-dark:
+        $value: '{color.purple.30}'
+        $description: 
+      surface:
+        on-light:
+          $value: '{color.purple.10}'
+          $description: 
+        on-dark:
+          $value: '{color.purple.60}'
+          $description: 
+
+    success:
+      on-light:
+        $value: '{color.green.60}'
+        $description: 
+      on-dark:
+        $value: '{color.green.40}'
+        $description: 
+      surface:
+        on-light:
+          $value: '{color.green.10}'
+          $description: 
+        on-dark:
+          $value: '{color.green.70}'
+          $description: 

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -20,14 +20,6 @@ color:
         $value: '{color.orange.40}'
         $description: Warning accent color (dark theme)
 
-    caution:
-      on-light:
-        $value: '{color.yellow.60}'
-        $description: Caution accent color (light theme)
-      on-dark:
-        $value: '{color.yellow.30}'
-        $description: Caution accent color (dark theme)
-
     default:
       on-light:
         $value: '{color.gray.60}'

--- a/tokens/color/surface.yaml
+++ b/tokens/color/surface.yaml
@@ -25,3 +25,46 @@ color:
     darkest:
       $value: '{color.gray.95}'
       $description: Primary surface (dark theme)
+
+    danger:
+      on-light:
+        $value: '{color.red-orange.10}'
+        $description: Danger surface color (light theme)
+      on-dark:
+        $value: '{color.red-orange.70}'
+        $description: Danger surface color (dark theme)
+    warning:
+      on-light:
+        $value: '{color.orange.10}'
+        $description: Warning surface color (light theme)
+      on-dark:
+        $value: '{color.orange.70}'
+        $description: Warning surface color (dark theme)
+    caution:
+      on-light:
+        $value: '{color.yellow.10}'
+        $description: Caution surface color (light theme)
+      on-dark:
+        $value: '{color.yellow.70}'
+        $description: Caution surface color (dark theme)
+    neutral:
+      on-light:
+        $value: '{color.gray.10}'
+        $description: Neutral surface color (light theme)
+      on-dark:
+        $value: '{color.gray.80}'
+        $description: Neutral surface color (dark theme)
+    note:
+      on-light:
+        $value: '{color.purple.10}'
+        $description: Note surface color (light theme)
+      on-dark:
+        $value: '{color.purple.60}'
+        $description: Note surface color (dark theme)
+    success:
+      on-light:
+        $value: '{color.green.10}'
+        $description: Success surface color (light theme)
+      on-dark:
+        $value: '{color.green.70}'
+        $description: Success surface color (dark theme)

--- a/tokens/color/surface.yaml
+++ b/tokens/color/surface.yaml
@@ -26,45 +26,39 @@ color:
       $value: '{color.gray.95}'
       $description: Primary surface (dark theme)
 
-    danger:
-      on-light:
-        $value: '{color.red-orange.10}'
-        $description: Danger surface color (light theme)
-      on-dark:
-        $value: '{color.red-orange.70}'
-        $description: Danger surface color (dark theme)
-    warning:
-      on-light:
-        $value: '{color.orange.10}'
-        $description: Warning surface color (light theme)
-      on-dark:
-        $value: '{color.orange.70}'
-        $description: Warning surface color (dark theme)
-    caution:
-      on-light:
-        $value: '{color.yellow.10}'
-        $description: Caution surface color (light theme)
-      on-dark:
-        $value: '{color.yellow.70}'
-        $description: Caution surface color (dark theme)
-    default:
-      on-light:
-        $value: '{color.gray.10}'
-        $description: Default surface color (light theme)
-      on-dark:
-        $value: '{color.gray.80}'
-        $description: Default surface color (dark theme)
-    info:
-      on-light:
-        $value: '{color.purple.10}'
-        $description: Info surface color (light theme)
-      on-dark:
-        $value: '{color.purple.60}'
-        $description: Info surface color (dark theme)
-    success:
-      on-light:
-        $value: '{color.green.10}'
-        $description: Success surface color (light theme)
-      on-dark:
-        $value: '{color.green.70}'
-        $description: Success surface color (dark theme)
+    status:
+      danger:
+        on-light:
+          $value: '{color.red-orange.10}'
+          $description: Danger status surface color (light theme)
+        on-dark:
+          $value: '{color.red-orange.70}'
+          $description: Danger status surface color (dark theme)
+      warning:
+        on-light:
+          $value: '{color.orange.10}'
+          $description: Warning status surface color (light theme)
+        on-dark:
+          $value: '{color.orange.70}'
+          $description: Warning status surface color (dark theme)
+      default:
+        on-light:
+          $value: '{color.gray.10}'
+          $description: Default status surface color (light theme)
+        on-dark:
+          $value: '{color.gray.80}'
+          $description: Default status surface color (dark theme)
+      info:
+        on-light:
+          $value: '{color.purple.10}'
+          $description: Info status surface color (light theme)
+        on-dark:
+          $value: '{color.purple.60}'
+          $description: Info status surface color (dark theme)
+      success:
+        on-light:
+          $value: '{color.green.10}'
+          $description: Success status surface color (light theme)
+        on-dark:
+          $value: '{color.green.70}'
+          $description: Success status surface color (dark theme)

--- a/tokens/color/surface.yaml
+++ b/tokens/color/surface.yaml
@@ -47,20 +47,20 @@ color:
       on-dark:
         $value: '{color.yellow.70}'
         $description: Caution surface color (dark theme)
-    neutral:
+    default:
       on-light:
         $value: '{color.gray.10}'
-        $description: Neutral surface color (light theme)
+        $description: Default surface color (light theme)
       on-dark:
         $value: '{color.gray.80}'
-        $description: Neutral surface color (dark theme)
-    note:
+        $description: Default surface color (dark theme)
+    info:
       on-light:
         $value: '{color.purple.10}'
-        $description: Note surface color (light theme)
+        $description: Info surface color (light theme)
       on-dark:
         $value: '{color.purple.60}'
-        $description: Note surface color (dark theme)
+        $description: Info surface color (dark theme)
     success:
       on-light:
         $value: '{color.green.10}'


### PR DESCRIPTION
This PR:
- adds default, border, and surface status tokens
- fixes a duplicated red orange value
- changes the max width of the copy button to show full token name
- changes order of categories on Netlify page

To see what these tokens look like when used with our components: [Figma file](https://www.figma.com/file/FAhXoct6VdXsoRDkwHBLMK/Status-colors?type=design&node-id=28%3A562&mode=design&t=LfGcXsxzmPtsO0fF-1)