### PR TITLE
feat: update danger status tokens

### DIFF
--- a/tokens/color/icon.yml
+++ b/tokens/color/icon.yml
@@ -55,6 +55,7 @@ color:
         on-light:
           $value: '{color.orange.50}'
           $description: Warning status icon color (light theme)
+        on-dark:
           $value: '{color.orange.40}'
           $description: Warning status icon color (dark theme)
       default:

--- a/tokens/color/icon.yml
+++ b/tokens/color/icon.yml
@@ -43,3 +43,38 @@ color:
           category: icon
           type: color
 
+    status:
+      danger:
+        on-light:
+          $value: '{color.red-orange.50}'
+          $description: Danger status icon color (light theme)
+        on-dark:
+          $value: '{color.red-orange.40}'
+          $description: Danger status icon color (dark theme)
+      warning:
+        on-light:
+          $value: '{color.orange.50}'
+          $description: Warning status icon color (light theme)
+          $value: '{color.orange.40}'
+          $description: Warning status icon color (dark theme)
+      default:
+        on-light:
+          $value: '{color.gray.60}'
+          $description: Default status icon color (light theme)
+        on-dark:
+          $value: '{color.gray.40}'
+          $description: Default status icon color (dark theme)
+      info:
+        on-light:
+          $value: '{color.purple.50}'
+          $description: Info status icon color (light theme)
+        on-dark:
+          $value: '{color.purple.30}'
+          $description: Info status icon color (dark theme)
+      success:
+        on-light:
+          $value: '{color.green.60}'
+          $description: Success status icon color (light theme)
+        on-dark:
+          $value: '{color.green.40}'
+          $description: Success status icon color (dark theme)

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -6,7 +6,7 @@ color:
 
     danger:
       on-light:
-        $value: '{color.red-orange.50}'
+        $value: '{color.red-orange.60}'
         $description: Danger accent color (light theme)
       on-dark:
         $value: '{color.red-orange.40}'


### PR DESCRIPTION
- Changed value of `--rh-color-status-danger-on-light` from `red-orange-50` to `red-orange-60` to align with design language. This token would typically be used for tag or button backgrounds.
- Added status icon color tokens. This is so we can continue using `red-orange-50` as an icon color in light theme.