### PR TITLE
feat: align status color tokens

### DIFF
--- a/.changeset/twelve-brooms-relax.md
+++ b/.changeset/twelve-brooms-relax.md
@@ -1,0 +1,40 @@
+---
+"@rhds/tokens": minor
+---
+
+Align status tokens across color categories by:
+
+- Update status token values for danger, warning, caution, neutral, and success
+
+- Add info status token, which should be used in place of note status token going forward
+
+
+- Ensure consistent status color names by aliasing inconsistent names with new names:
+
+Before:
+```
+    color.status.note.on-light:
+        $value: color.purple.50
+```
+
+After:
+```
+    color.status.note.on-light:
+        $value: color.status.info.on-light
+```
+
+- Alias icon and border status token values to status tokens
+
+Before:
+```
+    color.icon.status.success.on-light:
+        $value: color.green.60
+```
+
+After:
+```
+    color.icon.status.success.on-light:
+        $value: color.status.success.on-light
+```
+
+- Update surface color status token names and values

--- a/.changeset/twelve-brooms-relax.md
+++ b/.changeset/twelve-brooms-relax.md
@@ -4,37 +4,20 @@
 
 Align status tokens across color categories by:
 
-- Update status token values for danger, warning, caution, neutral, and success
-
-- Add info status token, which should be used in place of note status token going forward
-
-
-- Ensure consistent status color names by aliasing inconsistent names with new names:
-
-Before:
-```
-    color.status.note.on-light:
-        $value: color.purple.50
-```
-
-After:
-```
-    color.status.note.on-light:
-        $value: color.status.info.on-light
-```
-
-- Alias icon and border status token values to status tokens
-
-Before:
-```
-    color.icon.status.success.on-light:
-        $value: color.green.60
-```
-
-After:
-```
-    color.icon.status.success.on-light:
-        $value: color.status.success.on-light
-```
-
 - Update surface color status token names and values
+- Update status token values for `danger`, `warning`, `caution`, `neutral`, and `success`
+- Add `info` status token, which should be used in place of `note` status token going forward
+- Ensure consistent status color names by aliasing inconsistent names with new names:  
+  ```diff
+  - color: var(--rh-color-status-note-on-light,
+  -   var(--rh-color-purple-50, #5e40be))
+  + color: var(--rh-color-status-info-on-light,
+  +  var(--rh-color-purple-50, #5e40be))
+  ```
+- Alias icon and border status token values to status tokens  
+  ```diff
+  - color: var(--rh-color-icon-status-success-on-light,
+  -   var(--rh-color-green-60, #3d7317));
+  + color: var(--rh-color-status-success-on-light,
+  +  var(--rh-color-green-60, #3d7317));
+  ```

--- a/.changeset/twelve-brooms-relax.md
+++ b/.changeset/twelve-brooms-relax.md
@@ -11,11 +11,13 @@ Align status tokens across color categories by:
   ```diff
   - color: var(--rh-color-status-note-on-light,
   + color: var(--rh-color-status-info-on-light,
-     var(--rh-color-purple-50, #5e40be))
+      var(--rh-color-purple-50, #5e40be))
   ```
 - Alias icon and border status token values to status tokens  
   ```diff
   - color: var(--rh-color-icon-status-success-on-light,
-  + color: var(--rh-color-status-success-on-light,
-     var(--rh-color-green-60, #3d7317));
+  -   var(--rh-color-green-60, #3d7317));
+  + color: var(--rh-color-icon-status-success-on-light,
+  +   var(--rh-color-status-success-on-light,
+  +     var(--rh-color-green-60, #3d7317));
   ```

--- a/.changeset/twelve-brooms-relax.md
+++ b/.changeset/twelve-brooms-relax.md
@@ -10,14 +10,12 @@ Align status tokens across color categories by:
 - Ensure consistent status color names by aliasing inconsistent names with new names:  
   ```diff
   - color: var(--rh-color-status-note-on-light,
-  -   var(--rh-color-purple-50, #5e40be))
   + color: var(--rh-color-status-info-on-light,
-  +  var(--rh-color-purple-50, #5e40be))
+     var(--rh-color-purple-50, #5e40be))
   ```
 - Alias icon and border status token values to status tokens  
   ```diff
   - color: var(--rh-color-icon-status-success-on-light,
-  -   var(--rh-color-green-60, #3d7317));
   + color: var(--rh-color-status-success-on-light,
-  +  var(--rh-color-green-60, #3d7317));
+     var(--rh-color-green-60, #3d7317));
   ```

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -35,7 +35,7 @@ color:
           - '{color.border.subtle.on-light}'
           - '{color.border.subtle.on-dark}'
         $description: >-
-          Responsive `border-subtle` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `border-subtle` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-border-subtle-on-light` on a themable container with a light color palette
           and `--rh-color-border-subtle-on-dark` on a themable container with a dark color palette.
       on-light:
@@ -57,7 +57,7 @@ color:
           - '{color.border.interactive.on-light}'
           - '{color.border.interactive.on-dark}'
         $description: >-
-          Responsive `border-interactive` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `border-interactive` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-border-interactive-on-light` on a themable container with a light color palette
           and `--rh-color-border-interactive-on-dark` on a themable container with a dark color palette.
       on-light:
@@ -73,24 +73,153 @@ color:
           category: border
           type: color
 
+#remove destructive during next major release
     destructive:
       _:
         $value:
           - '{color.border.destructive.on-light}'
           - '{color.border.destructive.on-dark}'
         $description: >-
-          Responsive `border-destructive` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `border-destructive` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-border-destructive-on-light` on a themable container with a light color palette
           and `--rh-color-border-destructive-on-dark` on a themable container with a dark color palette.
       on-light:
-        $value: '{color.red-orange.60}'
+        $value: '{color.border.status.danger.on-light}'
         $description: Destructive border color (light theme)
         attributes:
           category: border
           type: color
       on-dark:
-        $value: '{color.red-orange.40}'
+        $value: '{color.border.status.danger.on-dark}'
         $description: Destructive border color (dark theme)
         attributes:
           category: border
           type: color
+#danger should replace destructive during next major release
+    status:
+      danger:
+        _:
+          $value:
+            - '{color.border.status.danger.on-light}'
+            - '{color.border.status.danger.on-dark}'
+          $description: >-
+            Responsive `border-danger` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-border-danger-on-light` on a themable container with a light color palette
+            and `--rh-color-border-danger-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.danger.on-light}'
+          $description: Danger border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.status.danger.on-dark}'
+          $description: Danger border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      caution:
+        _:
+          $value:
+            - '{color.border.status.caution.on-light}'
+            - '{color.border.status.caution.on-dark}'
+          $description: >-
+            Responsive `border-caution` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-border-caution-on-light` on a themable container with a light color palette
+            and `--rh-color-border-caution-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.caution.on-light}'
+          $description: Caution border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.status.caution.on-dark}'
+          $description: Caution border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      warning:
+        _:
+          $value:
+            - '{color.border.status.warning.on-light}'
+            - '{color.border.status.warning.on-dark}'
+          $description: >-
+            Responsive `border-warning` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-border-warning-on-light` on a themable container with a light color palette
+            and `--rh-color-border-warning-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.warning.on-light}'
+          $description: Warning border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.status.warning.on-dark}'
+          $description: Warning border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      neutral:
+        _:
+          $value:
+            - '{color.border.status.neutral.on-light}'
+            - '{color.border.status.neutral.on-dark}'
+          $description: >-
+            Responsive `border-neutral` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-border-neutral-on-light` on a themable container with a light color palette
+            and `--rh-color-border-neutral-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.neutral.on-light}'
+          $description: Neutral border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.status.neutral.on-dark}'
+          $description: Neutral border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      info:
+        _:
+          $value:
+            - '{color.border.status.info.on-light}'
+            - '{color.border.status.info.on-dark}'
+          $description: >-
+            Responsive `border-info` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-border-info-on-light` on a themable container with a light color palette
+            and `--rh-color-border-info-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.info.on-light}'
+          $description: Info border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.status.info.on-dark}'
+          $description: Info border color (dark theme)
+          attributes:
+            category: border
+            type: color
+      success:
+        _:
+          $value:
+            - '{color.border.status.success.on-light}'
+            - '{color.border.status.success.on-dark}'
+          $description: >-
+            Responsive `border-success` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-border-success-on-light` on a themable container with a light color palette
+            and `--rh-color-border-success-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.success.on-light}'
+          $description: Success border color (light theme)
+          attributes:
+            category: border
+            type: color
+        on-dark:
+          $value: '{color.status.success.on-dark}'
+          $description: Success border color (dark theme)
+          attributes:
+            category: border
+            type: color

--- a/tokens/color/border.yml
+++ b/tokens/color/border.yml
@@ -73,7 +73,7 @@ color:
           category: border
           type: color
 
-#remove destructive during next major release
+    # remove destructive during next major release
     destructive:
       _:
         $value:
@@ -95,8 +95,8 @@ color:
         attributes:
           category: border
           type: color
-#danger should replace destructive during next major release
     status:
+      # status-danger should replace destructive during next major release
       danger:
         _:
           $value:

--- a/tokens/color/icon.yml
+++ b/tokens/color/icon.yml
@@ -12,7 +12,7 @@ color:
           - '{color.icon.primary.on-light}'
           - '{color.icon.primary.on-dark}'
         $description: >-
-          Responsive `icon-primary` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `icon-primary` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-icon-primary-on-light` on a themable container with a light color palette
           and `--rh-color-icon-primary-on-dark` on a themable container with a dark color palette.
       on-light:
@@ -32,7 +32,7 @@ color:
           - '{color.icon.secondary.on-light}'
           - '{color.icon.secondary.on-dark}'
         $description: >-
-          Responsive `icon-secondary` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `icon-secondary` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-icon-secondary-on-light` on a themable container with a light color palette
           and `--rh-color-icon-secondary-on-dark` on a themable container with a dark color palette.
       on-light:
@@ -66,59 +66,91 @@ color:
             - '{color.icon.status.danger.on-light}'
             - '{color.icon.status.danger.on-dark}'
           $description: >-
-            Responsive `icon-status-danger` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `icon-status-danger` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-icon-status-danger-on-light` on a themable container with a light color palette
             and `--rh-color-icon-status-danger-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.red-orange.50}'
+          $value: '{color.status.danger.on-light}'
           $description: Danger status icon color (light theme)
         on-dark:
-          $value: '{color.red-orange.40}'
+          $value: '{color.status.danger.on-dark}'
           $description: Danger status icon color (dark theme)
+      caution:
+        _:
+          $value:
+            - '{color.icon.status.caution.on-light}'
+            - '{color.icon.status.caution.on-dark}'
+          $description: >-
+            Responsive `icon-status-caution` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-icon-status-caution-on-light` on a themable container with a light color palette
+            and `--rh-color-icon-status-caution-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.caution.on-light}'
+          $description: Caution status icon color (light theme)
+        on-dark:
+          $value: '{color.status.caution.on-dark}'
+          $description: Caution status icon color (dark theme)
       warning:
         _:
           $value:
             - '{color.icon.status.warning.on-light}'
             - '{color.icon.status.warning.on-dark}'
           $description: >-
-            Responsive `icon-status-warning` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `icon-status-warning` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-icon-status-warning-on-light` on a themable container with a light color palette
             and `--rh-color-icon-status-warning-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.orange.50}'
+          $value: '{color.status.warning.on-light}'
           $description: Warning status icon color (light theme)
         on-dark:
-          $value: '{color.orange.40}'
+          $value: '{color.status.warning.on-dark}'
           $description: Warning status icon color (dark theme)
+      #default status token should be removed during next major release
       default:
         _:
           $value:
             - '{color.icon.status.default.on-light}'
             - '{color.icon.status.default.on-dark}'
           $description: >-
-            Responsive `icon-status-default` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `icon-status-default` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-icon-status-default-on-light` on a themable container with a light color palette
             and `--rh-color-icon-status-default-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.gray.60}'
+          $value: '{color.icon.status.neutral.on-light}'
           $description: Default status icon color (light theme)
         on-dark:
-          $value: '{color.gray.40}'
+          $value: '{color.icon.status.neutral.on-light}'
           $description: Default status icon color (dark theme)
+      #neutral status token replaces default status token
+      neutral:
+        _:
+          $value:
+            - '{color.icon.status.neutral.on-light}'
+            - '{color.icon.status.neutral.on-dark}'
+          $description: >-
+            Responsive `icon-status-neutral` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-icon-status-neutral-on-light` on a themable container with a light color palette
+            and `--rh-color-icon-status-neutral-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.status.neutral.on-light}'
+          $description: Neutral status icon color (light theme)
+        on-dark:
+          $value: '{color.status.neutral.on-dark}'
+          $description: Neutral status icon color (dark theme)
       info:
         _:
           $value:
             - '{color.icon.status.info.on-light}'
             - '{color.icon.status.info.on-dark}'
           $description: >-
-            Responsive `icon-status-info` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `icon-status-info` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-icon-status-info-on-light` on a themable container with a light color palette
             and `--rh-color-icon-status-info-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.purple.50}'
+          $value: '{color.status.info.on-light}'
           $description: Info status icon color (light theme)
         on-dark:
-          $value: '{color.purple.30}'
+          $value: '{color.status.info.on-dark}'
           $description: Info status icon color (dark theme)
       success:
         _:
@@ -126,12 +158,12 @@ color:
             - '{color.icon.status.success.on-light}'
             - '{color.icon.status.success.on-dark}'
           $description: >-
-            Responsive `icon-status-success` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `icon-status-success` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-icon-status-success-on-light` on a themable container with a light color palette
             and `--rh-color-icon-status-success-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.green.60}'
+          $value: '{color.status.success.on-light}'
           $description: Success status icon color (light theme)
         on-dark:
-          $value: '{color.green.40}'
+          $value: '{color.status.success.on-dark}'
           $description: Success status icon color (dark theme)

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -12,33 +12,15 @@ color:
           - '{color.status.danger.on-light}'
           - '{color.status.danger.on-dark}'
         $description: >-
-          Responsive `status-danger` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `status-danger` color value. Typically read-only – use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-status-danger-on-light` on a themable container with a light color palette
           and `--rh-color-status-danger-on-dark` on a themable container with a dark color palette.
       on-light:
-        $value: '{color.red-orange.50}'
+        $value: '{color.red-orange.60}'
         $description: Danger status color (light theme)
       on-dark:
         $value: '{color.red-orange.50}'
         $description: Danger status color (dark theme)
-
-    warning:
-      $description: >-
-        Represents an action or notice which elicits a warning of potential danger
-      _:
-        $value:
-          - '{color.status.warning.on-light}'
-          - '{color.status.warning.on-dark}'
-        $description: >-
-          Responsive `status-warning` color value. Typically read only - use a themable container e.g. `<rh-surface>`
-          Resolves to `--rh-color-status-warning-on-light` on a themable container with a light color palette
-          and `--rh-color-status-warning-on-dark` on a themable container with a dark color palette.
-      on-light:
-        $value: '{color.orange.50}'
-        $description: Warning status color (light theme)
-      on-dark:
-        $value: '{color.orange.40}'
-        $description: Warning status color (dark theme)
 
     caution:
       $description: >-
@@ -48,15 +30,33 @@ color:
           - '{color.status.caution.on-light}'
           - '{color.status.caution.on-dark}'
         $description: >-
-          Responsive `status-caution` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `status-caution` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-status-caution-on-light` on a themable container with a light color palette
           and `--rh-color-status-caution-on-dark` on a themable container with a dark color palette.
       on-light:
-        $value: '{color.yellow.30}'
+        $value: '{color.orange.50}'
         $description: Caution status color (light theme)
       on-dark:
-        $value: '{color.orange.30}'
+        $value: '{color.orange.40}'
         $description: Caution status color (dark theme)
+
+    warning:
+      $description: >-
+        Represents an action or notice which elicits a warning of potential danger
+      _:
+        $value:
+          - '{color.status.warning.on-light}'
+          - '{color.status.warning.on-dark}'
+        $description: >-
+          Responsive `status-warning` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+          Resolves to `--rh-color-status-warning-on-light` on a themable container with a light color palette
+          and `--rh-color-status-warning-on-dark` on a themable container with a dark color palette.
+      on-light:
+        $value: '{color.yellow.40}'
+        $description: Warning status color (light theme)
+      on-dark:
+        $value: '{color.yellow.30}'
+        $description: Warning status color (dark theme)
 
     neutral:
       $description: >-
@@ -64,19 +64,20 @@ color:
         is neither explicitly constructive or explicitly destructive.
       _:
         $value:
-          - '{color.status.caution.on-light}'
-          - '{color.status.caution.on-dark}'
+          - '{color.status.neutral.on-light}'
+          - '{color.status.neutral.on-dark}'
         $description: >-
-          Responsive `status-warning` color value. Typically read only - use a themable container e.g. `<rh-surface>`
-          Resolves to `--rh-color-status-warning-on-light` on a themable container with a light color palette
-          and `--rh-color-status-warning-on-dark` on a themable container with a dark color palette.
+          Responsive `status-neutral` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+          Resolves to `--rh-color-status-neutral-on-light` on a themable container with a light color palette
+          and `--rh-color-status-neutral-on-dark` on a themable container with a dark color palette.
       on-light:
-        $value: '{color.yellow.30}'
-        $description: Warning accent color (light theme)
+        $value: '{color.gray.60}'
+        $description: Neutral accent color (light theme)
       on-dark:
-        $value: '{color.orange.30}'
-        $description: Warning accent color (dark theme)
+        $value: '{color.gray.30}'
+        $description: Neutral accent color (dark theme)
 
+# Note: note token should be phased out in the next major release.
     note:
       $description: >-
         Represents an action or notice which is informational, or a tip on how best to complete a task.
@@ -85,15 +86,34 @@ color:
           - '{color.status.note.on-light}'
           - '{color.status.note.on-dark}'
         $description: >-
-          Responsive `status-note` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `status-note` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-status-note-on-light` on a themable container with a light color palette
           and `--rh-color-status-note-on-dark` on a themable container with a dark color palette.
       on-light:
-        $value: '{color.purple.50}'
+        $value: '{color.status.info.on-light}'
         $description: Note/tip status color (light theme)
       on-dark:
-        $value: '{color.purple.30}'
+        $value: '{color.status.info.on-dark}'
         $description: Note/tip status color (dark theme)
+
+# info token should be used in place of note token.
+    info:
+      $description: >-
+        Represents an action or notice which is informational, or a tip on how best to complete a task.
+      _:
+        $value:
+          - '{color.status.info.on-light}'
+          - '{color.status.info.on-dark}'
+        $description: >-
+          Responsive `status-info` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+          Resolves to `--rh-color-status-info-on-light` on a themable container with a light color palette
+          and `--rh-color-status-info-on-dark` on a themable container with a dark color palette.
+      on-light:
+        $value: '{color.purple.50}'
+        $description: Info status color (light theme)
+      on-dark:
+        $value: '{color.purple.30}'
+        $description: Info status color (dark theme)
 
     success:
       $description: >-
@@ -103,12 +123,12 @@ color:
           - '{color.status.success.on-light}'
           - '{color.status.success.on-dark}'
         $description: >-
-          Responsive `status-success` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+          Responsive `status-success` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
           Resolves to `--rh-color-status-success-on-light` on a themable container with a light color palette
           and `--rh-color-status-success-on-dark` on a themable container with a dark color palette.
       on-light:
-        $value: '{color.green.50}'
+        $value: '{color.green.60}'
         $description: Success status color (light theme)
       on-dark:
-        $value: '{color.green.50}'
+        $value: '{color.green.40}'
         $description: Success status color (dark theme)

--- a/tokens/color/status.yaml
+++ b/tokens/color/status.yaml
@@ -77,7 +77,7 @@ color:
         $value: '{color.gray.30}'
         $description: Neutral accent color (dark theme)
 
-# Note: note token should be phased out in the next major release.
+    # note token should be phased out in the next major release.
     note:
       $description: >-
         Represents an action or notice which is informational, or a tip on how best to complete a task.
@@ -96,7 +96,7 @@ color:
         $value: '{color.status.info.on-dark}'
         $description: Note/tip status color (dark theme)
 
-# info token should be used in place of note token.
+    # info token should be used in place of note token.
     info:
       $description: >-
         Represents an action or notice which is informational, or a tip on how best to complete a task.

--- a/tokens/color/surface.yaml
+++ b/tokens/color/surface.yaml
@@ -12,7 +12,7 @@ color:
         - '{color.surface.darker}'
         - '{color.surface.darkest}'
       $description: >-
-        Responsive `surface` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+        Responsive `surface` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
         Resolves to the surface color corresponding to the surface' color palette.
 
     lightest:
@@ -44,59 +44,91 @@ color:
             - '{color.surface.status.danger.on-light}'
             - '{color.surface.status.danger.on-dark}'
           $description: >-
-            Responsive `surface-status-danger` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `surface-status-danger` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-surface-status-danger-on-light` on a themable container with a light color palette
             and `--rh-color-surface-status-danger-on-dark` on a themable container with a dark color palette.
         on-light:
           $value: '{color.red-orange.10}'
           $description: Danger status surface color (light theme)
         on-dark:
-          $value: '{color.red-orange.70}'
+          $value: '{color.red-orange.10}'
           $description: Danger status surface color (dark theme)
+      caution:
+        _:
+          $value:
+            - '{color.surface.status.caution.on-light}'
+            - '{color.surface.status.caution.on-dark}'
+          $description: >-
+            Responsive `surface-status-caution` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-surface-status-caution-on-light` on a themable container with a light color palette
+            and `--rh-color-surface-status-caution-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.orange.10}'
+          $description: Caution status surface color (light theme)
+        on-dark:
+          $value: '{color.orange.10}'
+          $description: Caution status surface color (dark theme)
       warning:
         _:
           $value:
             - '{color.surface.status.warning.on-light}'
             - '{color.surface.status.warning.on-dark}'
           $description: >-
-            Responsive `surface-status-warning` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `surface-status-warning` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-surface-status-warning-on-light` on a themable container with a light color palette
             and `--rh-color-surface-status-warning-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.orange.10}'
+          $value: '{color.yellow.10}'
           $description: Warning status surface color (light theme)
         on-dark:
-          $value: '{color.orange.70}'
+          $value: '{color.yellow.70}'
           $description: Warning status surface color (dark theme)
+      # remove default during the next major release
       default:
         _:
           $value:
             - '{color.surface.status.default.on-light}'
             - '{color.surface.status.default.on-dark}'
           $description: >-
-            Responsive `surface-status-default` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `surface-status-default` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-surface-status-default-on-light` on a themable container with a light color palette
             and `--rh-color-surface-status-default-on-dark` on a themable container with a dark color palette.
         on-light:
-          $value: '{color.gray.10}'
+          $value: '{color.surface.status.neutral.on-light}'
           $description: Default status surface color (light theme)
         on-dark:
-          $value: '{color.gray.80}'
+          $value: '{color.surface.status.neutral.on-light}'
           $description: Default status surface color (dark theme)
+      # neutral will replace default in next major release
+      neutral:
+        _:
+          $value:
+            - '{color.surface.status.neutral.on-light}'
+            - '{color.surface.status.neutral.on-dark}'
+          $description: >-
+            Responsive `surface-status-neutral` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
+            Resolves to `--rh-color-surface-status-neutral-on-light` on a themable container with a light color palette
+            and `--rh-color-surface-status-neutral-on-dark` on a themable container with a dark color palette.
+        on-light:
+          $value: '{color.gray.10}'
+          $description: Neutral status surface color (light theme)
+        on-dark:
+          $value: '{color.gray.10}'
+          $description: Neutral status surface color (dark theme)
       info:
         _:
           $value:
             - '{color.surface.status.info.on-light}'
             - '{color.surface.status.info.on-dark}'
           $description: >-
-            Responsive `surface-status-info` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `surface-status-info` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-surface-status-info-on-light` on a themable container with a light color palette
             and `--rh-color-surface-status-info-on-dark` on a themable container with a dark color palette.
         on-light:
           $value: '{color.purple.10}'
           $description: Info status surface color (light theme)
         on-dark:
-          $value: '{color.purple.60}'
+          $value: '{color.purple.10}'
           $description: Info status surface color (dark theme)
       success:
         _:
@@ -104,12 +136,12 @@ color:
             - '{color.surface.status.success.on-light}'
             - '{color.surface.status.success.on-dark}'
           $description: >-
-            Responsive `surface-status-success` color value. Typically read only - use a themable container e.g. `<rh-surface>`
+            Responsive `surface-status-success` color value. Typically read-only - use a themable container, e.g. `<rh-surface>`.
             Resolves to `--rh-color-surface-status-success-on-light` on a themable container with a light color palette
             and `--rh-color-surface-status-success-on-dark` on a themable container with a dark color palette.
         on-light:
           $value: '{color.green.10}'
           $description: Success status surface color (light theme)
         on-dark:
-          $value: '{color.green.70}'
+          $value: '{color.green.10}'
           $description: Success status surface color (dark theme)


### PR DESCRIPTION
- Updated `color/status.yaml` file to align with crayon color values from this [updated Figma file](https://www.figma.com/design/FAhXoct6VdXsoRDkwHBLMK/Status-colors?node-id=193-525&m=dev)
- Aliased old status token names to new names
- Updated status colors for borders and icons to reference `rh-color-status` token values, instead of crayon colors
- Updated surface colors based on crayon color values from the same [updated Figma file]

**Notes:**
- When the Figma file showed "N/A" for a surface status color in dark theme, I used the same crayon token value as the light theme.
- I did not add any `rh-color-text-status` tokens in this PR, but they can be added if necessary.