### PR TITLE
fix: filter theme tokens scss

### DIFF
--- a/.changeset/pink-cameras-reflect.md
+++ b/.changeset/pink-cameras-reflect.md
@@ -1,0 +1,5 @@
+---
+"@rhds/tokens": patch
+---
+
+Removed empty color theme tokens from \_variables.scss

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -58,6 +58,7 @@ scss:
   prefix: rh
   files:
     - destination: _variables.scss
+      filter: isNotThemeColorToken
       format: scss/variables
       options:
         fileHeader: redhat/legal


### PR DESCRIPTION
## What I did

- Added filter to scss variables format in platforms.yaml to filter out theme color tokens.

Closes #144 