### PR TITLE
feat: add `-80` primitive color tokens

### DIFF
--- a/.changeset/four-ligers-flow.md
+++ b/.changeset/four-ligers-flow.md
@@ -1,0 +1,12 @@
+---
+"@rhds/tokens": minor
+---
+
+Added the following `-80` primitive color tokens:
+- `red-80`
+- `orange-80`
+- `yellow-80`
+- `teal-80`
+- `purple-80`
+
+Changed the value of `--rh-color-brand-red-darkest` from `--rh-color-red-70` to `--rh-color-red-80`

--- a/tokens/color/brand.yml
+++ b/tokens/color/brand.yml
@@ -27,7 +27,7 @@ color:
         $description: Lightest brand red
       lighter:
         $value: '{color.red.30}'
-        $description: lighter brand red
+        $description: Lighter brand red
       light:
         $value: '{color.red.40}'
         $description: Light brand red
@@ -39,7 +39,7 @@ color:
         $value: '{color.red.70}'
         $description: Darker brand red
       darkest:
-        $value: '{color.red.70}'
+        $value: '{color.red.80}'
         $description: Darkest brand red
 
 

--- a/tokens/color/crayon/blue.yaml
+++ b/tokens/color/crayon/blue.yaml
@@ -25,5 +25,3 @@ color:
     70:
       $value: '#003366'
       $description: Alert - Info title text
-    80:
-      $value: '#002250'

--- a/tokens/color/crayon/blue.yaml
+++ b/tokens/color/crayon/blue.yaml
@@ -25,3 +25,5 @@ color:
     70:
       $value: '#003366'
       $description: Alert - Info title text
+    80:
+      $value: '#002250'

--- a/tokens/color/crayon/orange.yml
+++ b/tokens/color/crayon/orange.yml
@@ -22,4 +22,6 @@ color:
       $value: '#9E4A06'
     70:
       $value: '#732E00'
-      $description: 	Label - Filled (Orange) text color
+      $description: Label - Filled (Orange) text color
+    80:
+      $value: '#4D1F00'

--- a/tokens/color/crayon/purple.yaml
+++ b/tokens/color/crayon/purple.yaml
@@ -23,3 +23,5 @@ color:
     70:
       $value: '#21134D'
       $description: Inline link visited hover (light theme)
+    80:
+      $value: '#1B0D33'

--- a/tokens/color/crayon/red.yaml
+++ b/tokens/color/crayon/red.yaml
@@ -26,3 +26,6 @@ color:
     70:
       $value: '#5F0000'
       $description: Darker brand red
+    80:
+      $value: '#3F0000'
+      $description: Darkest brand red

--- a/tokens/color/crayon/teal.yaml
+++ b/tokens/color/crayon/teal.yaml
@@ -24,3 +24,5 @@ color:
     70:
       $value: '#004D4D'
       $description: Alert - Default title text
+    80:
+      $value: '#003333'

--- a/tokens/color/crayon/yellow.yaml
+++ b/tokens/color/crayon/yellow.yaml
@@ -23,3 +23,5 @@ color:
     70:
       $value: '#73480B'
       $description: Alert - Warning title text
+    80:
+      $value: '#54330B'


### PR DESCRIPTION
Added `-80` primitive color tokens based on values on Brand's [Color page](https://www.redhat.com/en/about/brand/standards/color)

*_Note_: Blues might be moved to the "Status palette" section (because it's a link color). Status colors only go up to `-70`, so we were asked to hold off on adding `blue-80`.