### PR TITLE
fix: correct dark value in getLightDarkValue() for `--rh-color-surface`

### DIFF
--- a/.changeset/tame-symbols-search.md
+++ b/.changeset/tame-symbols-search.md
@@ -1,0 +1,5 @@
+---
+"@rhds/tokens": patch
+---
+
+Fixed dark value for `--rh-color-surface` in light-dark()

--- a/lib/transforms/color.ts
+++ b/lib/transforms/color.ts
@@ -61,8 +61,10 @@ export function getLightDarkValue(token: Token) {
   if (typeof token.$value === 'string' && token.$value.startsWith('light-dark')) {
     return token.$value;
   } else {
-    const [light, dark] = token.$value;
-    const [lightRef, darkRef] = token.original.$value;
+    const [light] = token.$value;
+    const dark = token.$value.at(-1);
+    const [lightRef] = token.original.$value;
+    const darkRef = token.original.$value.at(-1);
     return `light-dark(${deref(lightRef, light)}, ${deref(darkRef, dark)})`;
   }
 }


### PR DESCRIPTION
## What I did

 - Corrected the output for `--rh-color-surface` in `getLightDarkValue()`.  

Because `rh-color-surface` has many values, not just two possible, we need to grab the last in the array instead of just restructuring the first two.

Closes https://github.com/RedHat-UX/red-hat-design-system/issues/2440 