### PR TITLE
chore: making red-05 color changeset a minor instead of a patch

### DIFF
--- a/.changeset/hungry-planets-study.md
+++ b/.changeset/hungry-planets-study.md
@@ -1,5 +1,5 @@
 ---
-"@rhds/tokens": patch
+"@rhds/tokens": minor
 ---
 
 Added new `red-05` crayon token


### PR DESCRIPTION
Changing the red-05 color changeset to a minor instead of patch.